### PR TITLE
Check if xml doc exists

### DIFF
--- a/Editor/CopyXMLDoc.cs
+++ b/Editor/CopyXMLDoc.cs
@@ -19,6 +19,11 @@ namespace RoR2EditorKit
         private static bool ShouldCopy()
         {
             var relativePath = Constants.AssetGUIDS.GetPath(Constants.AssetGUIDS.xmlDocGUID);
+            if (string.IsNullOrEmpty(relativePath))
+            {
+                return false;
+            }
+            
             var fullPath = Path.GetFullPath(relativePath);
             var fileName = Path.GetFileName(fullPath);
             var pathToCheck = Path.Combine(Constants.FolderPaths.ScriptAssembliesFolder, fileName);


### PR DESCRIPTION
`ThunderKit`'s `StageManifestFiles` pipeline doesn't copy .meta files, so the `Thunderstore` package is missing some .meta files, the annoying one being xml doc because it throws an error on each domain reload. Checking for file existence wouldn't hurt, and for a more permanent solution to the problem I made https://github.com/PassivePicasso/ThunderKit/pull/89 PR for `ThunderKit` to enable copying .meta files in `StageManifestFiles` 