### PR TITLE
MapNodeGroup Inspector Improvements

### DIFF
--- a/Assets/VisualElements/Components/MapNodeGroupInspector.uxml
+++ b/Assets/VisualElements/Components/MapNodeGroupInspector.uxml
@@ -16,6 +16,7 @@
         <ui:VisualElement name="PainterContainer" style="display: none;">
             <RoR2.Editor.ExtendedHelpBox message="The Painter for Map Nodes is a legacy feature and is not supported directly by Nebby. Bugs related to it will be fixed by the community" message-type="Info" />
             <uie:FloatField label="Painter Size" value="42,2" name="BrushSize" />
+            <uie:FloatField label="Distance Between Nodes" value="15" name="NodeDistance"/>
         </ui:VisualElement>
         <ui:VisualElement name="ButtonContainer">
             <ui:VisualElement style="flex-direction: row;">
@@ -24,7 +25,7 @@
             </ui:VisualElement>
             <ui:VisualElement style="flex-direction: row;">
                 <ui:Button text="Update Hull Masks" display-tooltip-when-elided="true" name="UpdateHullMasks" style="white-space: normal; flex-grow: 0; flex-direction: column; flex-wrap: nowrap; width: 48%;" />
-                <ui:Button text="Remove Node Excess" display-tooltip-when-elided="true" name="RemoveNodeExcess" style="flex-grow: 0; width: 48%;" />
+                <ui:Button text="Remove Unconnected Nodes" display-tooltip-when-elided="true" name="RemoveNodeExcess" style="flex-grow: 0; width: 48%;" />
             </ui:VisualElement>
             <ui:VisualElement style="flex-direction: row;">
                 <ui:Button text="Make Air Nodes" display-tooltip-when-elided="true" name="MakeAirNodes" style="white-space: normal; flex-grow: 0; flex-direction: column; flex-wrap: nowrap; width: 48%;" />

--- a/Editor/RoR2/Inspectors/ComponentInspectors/MapNodeGroupInspector.cs
+++ b/Editor/RoR2/Inspectors/ComponentInspectors/MapNodeGroupInspector.cs
@@ -200,21 +200,6 @@ namespace RoR2.Editor.Inspectors
                         c++;
                         continue;
                     }
-                    //List<MapNode.Link> buffer = new List<MapNode.Link>();
-                    // for (int i = 0; i < mapNode.links.Count; i++)
-                    // {
-                    //     //Make sure the other node exists and hasn't been deleted before.
-                    //     if (mapNode.links[i].nodeB)
-                    //     {
-                    //         //Too friccin close, get off
-                    //         if ((Vector3.Distance(mapNode.links[i].nodeB.gameObject.transform.position, mapNode.gameObject.transform.position) <= _maxDistance / 1.5))
-                    //         {
-                    //             DestroyImmediate(mapNode.gameObject);
-                    //             c++;
-                    //             break;
-                    //         }
-                    //     }
-                    // }
                 }
             }
             Debug.Log($"Removed {c} nodes that were not connected to anything.");
@@ -374,7 +359,6 @@ namespace RoR2.Editor.Inspectors
 
             int controlID = GUIUtility.GetControlID(FocusType.Keyboard | FocusType.Passive);
             _cachedMapNodeList = targetType.GetNodes();
-            //_maxDistance = MapNode.maxConnectionDistance;
             float zPainterOffset = _maxDistance / 2;
 
             if (Event.current.GetTypeForControl(controlID) == EventType.KeyDown)

--- a/Editor/RoR2/Inspectors/ComponentInspectors/MapNodeGroupInspector.cs
+++ b/Editor/RoR2/Inspectors/ComponentInspectors/MapNodeGroupInspector.cs
@@ -104,6 +104,11 @@ namespace RoR2.Editor.Inspectors
             painterSize.RegisterValueChangedCallback(evt => _painterSize = evt.newValue);
             painterSize.ConnectWithSetting(inspectorPreferenceSettings, nameof(painterSize), 4f);
             _painterSize = inspectorPreferenceSettings.GetOrCreateSetting<float>(nameof(painterSize));
+            
+            var nodeDistance = templateInstanceRoot.Q<FloatField>("NodeDistance");
+            nodeDistance.RegisterValueChangedCallback(evt => _maxDistance = evt.newValue);
+            nodeDistance.ConnectWithSetting(inspectorPreferenceSettings, nameof(nodeDistance), 15f);
+            _maxDistance = inspectorPreferenceSettings.GetOrCreateSetting<float>(nameof(nodeDistance));
 
             var roundHitPointToNearestGrid = templateInstanceRoot.Q<Toggle>("RoundPointToGrid");
             roundHitPointToNearestGrid.RegisterValueChangedCallback(evt => _roundHitPointToNearestGrid = evt.newValue);
@@ -196,23 +201,23 @@ namespace RoR2.Editor.Inspectors
                         continue;
                     }
                     //List<MapNode.Link> buffer = new List<MapNode.Link>();
-                    for (int i = 0; i < mapNode.links.Count; i++)
-                    {
-                        //Make sure the other node exists and hasn't been deleted before.
-                        if (mapNode.links[i].nodeB)
-                        {
-                            //Too friccin close, get off
-                            if ((Vector3.Distance(mapNode.links[i].nodeB.gameObject.transform.position, mapNode.gameObject.transform.position) <= _maxDistance / 1.5))
-                            {
-                                DestroyImmediate(mapNode.gameObject);
-                                c++;
-                                break;
-                            }
-                        }
-                    }
+                    // for (int i = 0; i < mapNode.links.Count; i++)
+                    // {
+                    //     //Make sure the other node exists and hasn't been deleted before.
+                    //     if (mapNode.links[i].nodeB)
+                    //     {
+                    //         //Too friccin close, get off
+                    //         if ((Vector3.Distance(mapNode.links[i].nodeB.gameObject.transform.position, mapNode.gameObject.transform.position) <= _maxDistance / 1.5))
+                    //         {
+                    //             DestroyImmediate(mapNode.gameObject);
+                    //             c++;
+                    //             break;
+                    //         }
+                    //     }
+                    // }
                 }
             }
-            Debug.Log($"Removed {c} nodes that were way too close to others.");
+            Debug.Log($"Removed {c} nodes that were not connected to anything.");
             AssetDatabase.SaveAssets();
         }
 
@@ -369,7 +374,7 @@ namespace RoR2.Editor.Inspectors
 
             int controlID = GUIUtility.GetControlID(FocusType.Keyboard | FocusType.Passive);
             _cachedMapNodeList = targetType.GetNodes();
-            _maxDistance = MapNode.maxConnectionDistance;
+            //_maxDistance = MapNode.maxConnectionDistance;
             float zPainterOffset = _maxDistance / 2;
 
             if (Event.current.GetTypeForControl(controlID) == EventType.KeyDown)
@@ -495,9 +500,9 @@ namespace RoR2.Editor.Inspectors
         //N: This is not my code, this is a code of a previous community member that was banned for being abhorrent, i dont have plans to support this tool if it breaks.
         private void PaintNodes(float currentMaxDistance, float zPainterOffset, List<MapNode> cachedMapNodeList)
         {
-            for (float x = _currentHitInfo.x - _painterSize, zCount = 0; x <= _currentHitInfo.x; x += currentMaxDistance - 4, zCount++)
+            for (float x = _currentHitInfo.x - _painterSize, zCount = 0; x <= _currentHitInfo.x; x += currentMaxDistance / 2, zCount++)
             {
-                for (float z = _currentHitInfo.z - _painterSize; z <= _currentHitInfo.z; z += currentMaxDistance - 4)
+                for (float z = _currentHitInfo.z - _painterSize; z <= _currentHitInfo.z; z += currentMaxDistance / 2)
                 {
                     //Haven't found a single node that is too close, feel free to spawn.
                     //We lift the pos in case terrain is not flat...


### PR DESCRIPTION
Renamed "Remove Node Excess" into "Remove Unconnected Nodes", now only removes nodes that are not connected to any other node.
Added option to change distance between nodes while using painter.