### PR TITLE
fixing hitbox gizmo not on lossy scale

### DIFF
--- a/Editor/RoR2/HitBoxGizmoDrawer.cs
+++ b/Editor/RoR2/HitBoxGizmoDrawer.cs
@@ -10,7 +10,7 @@ namespace RoR2.Editor
         private static void DrawGizmos(HitBox hitBox, GizmoType gizmoType)
         {
             Gizmos.color = Color.red;
-            Gizmos.DrawWireMesh(cubeMesh, hitBox.transform.position, hitBox.transform.rotation, hitBox.transform.localScale);
+            Gizmos.DrawWireMesh(cubeMesh, hitBox.transform.position, hitBox.transform.rotation, hitBox.transform.lossyScale);
         }
     }
 }


### PR DESCRIPTION
hitbox gizmo was showing local scale which was WRONG